### PR TITLE
Expand list of gems to install to work around conservative update

### DIFF
--- a/lib/bundle_update_interactive/cli.rb
+++ b/lib/bundle_update_interactive/cli.rb
@@ -34,7 +34,7 @@ module BundleUpdateInteractive
       say
       say Table.new(selected_gems).render
       say
-      BundlerCommands.update_gems_conservatively(*selected_gems.keys)
+      report.bundle_update!(*selected_gems.keys)
     end
 
     private


### PR DESCRIPTION
Some gems are "meta gems" that are composed of other gems locked at identical versions. For example, rails 7.0.4.3 requires activesupport =7.0.4.3, railties =7.0.4.3, and so on.

Therefore, running `bundle update --conservative rails` may not work depending on how strictly Bundler enforces "conservative" (this behavior is also slightly different in different Bundler releases). In this case, you might see a message from Bundler like:

> Attempted to update rails, but the version stayed the same

With this commit, `update-interactive` solves this problem by updating the entire suite of gems when a "meta gem" is selected for update. In other words, if you pick rails from the list of gems to update, `update-interactive` will automatically include activesupport, railies, etc. as well, ensuring that the update is successful.