### PR TITLE
Add Vim- and Emacs-like up/down keybindings

### DIFF
--- a/lib/bundle_update_interactive/cli/multi_select.rb
+++ b/lib/bundle_update_interactive/cli/multi_select.rb
@@ -39,6 +39,8 @@ class BundleUpdateInteractive::CLI
           exit(130)
         }
       )
+      add_keybindings
+
       @pastel = BundleUpdateInteractive.pastel
     end
 
@@ -50,6 +52,13 @@ class BundleUpdateInteractive::CLI
     private
 
     attr_reader :pastel, :table, :tty_prompt, :title
+
+    def add_keybindings
+      tty_prompt.on(:keypress) do |event|
+        tty_prompt.trigger(:keyup) if %w[k p].include?(event.value)
+        tty_prompt.trigger(:keydown) if %w[j n].include?(event.value)
+      end
+    end
 
     def help
       [


### PR DESCRIPTION
## Motivation

When I tried `bundle ui` for the first time, I found myself trying to move around the list with n/p and j/k. `yarn upgrade-interactive` listens for j/k keypresses to move around the table. Similarly, many CLIs support n/p to move up and down.

## Proposed Change

Add listeners for those keys as described in the [tty-prompt docs](https://github.com/dylnclrk/bundle_update_interactive/pull/new/add-vim-emacs-keybindings). To be honest, I wasn't totally sure what was going on in this file, so I'm not sure if this is the best place to set up these listeners.

![Screen Recording 2024-07-14 at 3 10 17 PM](https://github.com/user-attachments/assets/63c0c1ca-9427-43a3-9647-902d83618fa5)
