### PR TITLE
Properly handle non-GitHub git sources when inferring changelog URI

### DIFF
--- a/lib/bundle_update_interactive/outdated_gem.rb
+++ b/lib/bundle_update_interactive/outdated_gem.rb
@@ -35,7 +35,7 @@ module BundleUpdateInteractive
       return @changelog_uri if defined?(@changelog_uri)
 
       @changelog_uri =
-        if git_version_changed?
+        if git_version_changed? && github_repo
           "https://github.com/#{github_repo}/compare/#{current_git_version}...#{updated_git_version}"
         elsif rubygems_source?
           changelog_locator.find_changelog_uri(name: name, version: updated_version.to_s)

--- a/test/bundle_update_interactive/outdated_gem_test.rb
+++ b/test/bundle_update_interactive/outdated_gem_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module BundleUpdateInteractive
+  class OutdatedGemTest < Minitest::Test
+    def test_changelog_uri_delegates_to_changelog_locator_for_rubygems_source
+      changelog_locator = mock
+      ChangelogLocator.expects(:new).returns(changelog_locator)
+      changelog_locator.expects(:find_changelog_uri).with(name: "rails", version: "7.1.3.4")
+        .returns("https://github.com/rails/rails/releases/tag/v7.1.3.4")
+
+      outdated_gem = build(
+        :outdated_gem,
+        rubygems_source: true,
+        name: "rails",
+        updated_version: "7.1.3.4"
+      )
+
+      assert_equal "https://github.com/rails/rails/releases/tag/v7.1.3.4", outdated_gem.changelog_uri
+    end
+
+    def test_changelog_uri_builds_github_comparison_url_if_github_repo
+      outdated_gem = build(
+        :outdated_gem,
+        rubygems_source: false,
+        name: "mighty_test",
+        git_source_uri: "https://github.com/mattbrictson/mighty_test.git",
+        current_git_version: "302ad5c",
+        updated_git_version: "e27ab73"
+      )
+
+      assert_equal "https://github.com/mattbrictson/mighty_test/compare/302ad5c...e27ab73", outdated_gem.changelog_uri
+    end
+
+    def test_changelog_uri_falls_back_to_gem_spec_homepage_if_non_github_git_repo
+      Gem::Specification
+        .expects(:find_by_name)
+        .with("httpx")
+        .returns(Gem::Specification.new("httpx") { |spec| spec.homepage = "https://honeyryderchuck.gitlab.io/httpx/" })
+
+      outdated_gem = build(
+        :outdated_gem,
+        rubygems_source: false,
+        name: "httpx",
+        git_source_uri: "https://gitlab.com/os85/httpx.git",
+        current_git_version: "e250ea5",
+        updated_git_version: "7278647"
+      )
+
+      assert_equal "https://honeyryderchuck.gitlab.io/httpx/", outdated_gem.changelog_uri
+    end
+  end
+end


### PR DESCRIPTION
When a gem was sourced from a Git repository other than GitHub, `update-interactive` would build a malformed GitHub changelog URL. Fix the logic bug that caused this, and fall back to `Gem::Specification#homepage` for Git-sourced gems that come from non-GitHub repositories.