### PR TITLE
Add support for Bitbucket Cloud diff URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,17 @@ If you discover a gem that is missing a changelog in `bundle update-interactive`
 
 ### Git diffs
 
-If your `Gemfile` sources a gem from a GitHub repo like this:
+If your `Gemfile` sources a gem from a Git repo like this:
 
 ```ruby
 gem "rails", github: "rails/rails", branch: "7-1-stable"
 ```
 
-Then `bundle update-interactive` will show a GitHub diff link instead of a changelog, so you can see exactly what changed when the gem is updated. For example:
+Then `bundle update-interactive` will show a diff link instead of a changelog, so you can see exactly what changed when the gem is updated. For example:
 
 https://github.com/rails/rails/compare/5a8d894...77dfa65
 
-Currently only GitHub repos are supported, but I'm considering adding GitLab and BitBucket as well.
+This feature currently works for GitHub and Bitbucket repos. I'm considering adding support for GitLab as well.
 
 ### Conservative updates
 

--- a/test/bundle_update_interactive/outdated_gem_test.rb
+++ b/test/bundle_update_interactive/outdated_gem_test.rb
@@ -33,7 +33,23 @@ module BundleUpdateInteractive
       assert_equal "https://github.com/mattbrictson/mighty_test/compare/302ad5c...e27ab73", outdated_gem.changelog_uri
     end
 
-    def test_changelog_uri_falls_back_to_gem_spec_homepage_if_non_github_git_repo
+    def test_changelog_uri_builds_github_comparison_url_if_bitbucket_cloud_repo
+      outdated_gem = build(
+        :outdated_gem,
+        rubygems_source: false,
+        name: "atlassian-jwt",
+        git_source_uri: "https://bitbucket.org/atlassian/atlassian-jwt-ruby.git",
+        current_git_version: "7c06fd5",
+        updated_git_version: "e8b7a92"
+      )
+
+      assert_equal(
+        "https://bitbucket.org/atlassian/atlassian-jwt-ruby/branches/compare/e8b7a92..7c06fd5",
+        outdated_gem.changelog_uri
+      )
+    end
+
+    def test_changelog_uri_falls_back_to_gem_spec_homepage_if_unsupported_git_repo
       Gem::Specification
         .expects(:find_by_name)
         .with("httpx")


### PR DESCRIPTION
If the `Gemfile` sources a gem from a `bitbucket.org` repo, we now show a diff URL for the changelog, like this:

https://bitbucket.org/atlassian/atlassian-jwt-ruby/branches/compare/e8b7a92..7c06fd5

Previously this feature only worked with GitHub repos.