### PR TITLE
Add support for GitLab diff URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Then `bundle update-interactive` will show a diff link instead of a changelog, s
 
 https://github.com/rails/rails/compare/5a8d894...77dfa65
 
-This feature currently works for GitHub and Bitbucket repos. I'm considering adding support for GitLab as well.
+This feature currently works for GitHub, GitLab, and Bitbucket repos.
 
 ### Conservative updates
 

--- a/lib/bundle_update_interactive/outdated_gem.rb
+++ b/lib/bundle_update_interactive/outdated_gem.rb
@@ -61,6 +61,8 @@ module BundleUpdateInteractive
 
       if github_repo
         "https://github.com/#{github_repo}/compare/#{current_git_version}...#{updated_git_version}"
+      elsif gitlab_repo
+        "https://gitlab.com/os85/httpx/-/compare/#{current_git_version}...#{updated_git_version}"
       elsif bitbucket_cloud_repo
         "https://bitbucket.org/#{bitbucket_cloud_repo}/branches/compare/#{updated_git_version}..#{current_git_version}"
       end
@@ -70,6 +72,12 @@ module BundleUpdateInteractive
       return nil unless updated_git_version
 
       git_source_uri.to_s[%r{^(?:git@github.com:|https://github.com/)([^/]+/[^/]+?)(:?\.git)?(?:$|/)}i, 1]
+    end
+
+    def gitlab_repo
+      return nil unless updated_git_version
+
+      git_source_uri.to_s[%r{^(?:git@gitlab.com:|https://gitlab.com/)([^/]+/[^/]+?)(:?\.git)?(?:$|/)}i, 1]
     end
 
     def bitbucket_cloud_repo

--- a/test/bundle_update_interactive/outdated_gem_test.rb
+++ b/test/bundle_update_interactive/outdated_gem_test.rb
@@ -20,7 +20,7 @@ module BundleUpdateInteractive
       assert_equal "https://github.com/rails/rails/releases/tag/v7.1.3.4", outdated_gem.changelog_uri
     end
 
-    def test_changelog_uri_builds_github_comparison_url_if_github_repo
+    def test_changelog_uri_diff_url_for_github_repo
       outdated_gem = build(
         :outdated_gem,
         rubygems_source: false,
@@ -33,7 +33,7 @@ module BundleUpdateInteractive
       assert_equal "https://github.com/mattbrictson/mighty_test/compare/302ad5c...e27ab73", outdated_gem.changelog_uri
     end
 
-    def test_changelog_uri_builds_github_comparison_url_if_bitbucket_cloud_repo
+    def test_changelog_uri_builds_diff_url_for_bitbucket_cloud_repo
       outdated_gem = build(
         :outdated_gem,
         rubygems_source: false,
@@ -49,12 +49,7 @@ module BundleUpdateInteractive
       )
     end
 
-    def test_changelog_uri_falls_back_to_gem_spec_homepage_if_unsupported_git_repo
-      Gem::Specification
-        .expects(:find_by_name)
-        .with("httpx")
-        .returns(Gem::Specification.new("httpx") { |spec| spec.homepage = "https://honeyryderchuck.gitlab.io/httpx/" })
-
+    def test_changelog_uri_builds_diff_url_for_gitlab_repo
       outdated_gem = build(
         :outdated_gem,
         rubygems_source: false,
@@ -64,7 +59,25 @@ module BundleUpdateInteractive
         updated_git_version: "7278647"
       )
 
-      assert_equal "https://honeyryderchuck.gitlab.io/httpx/", outdated_gem.changelog_uri
+      assert_equal "https://gitlab.com/os85/httpx/-/compare/e250ea5...7278647", outdated_gem.changelog_uri
+    end
+
+    def test_changelog_uri_falls_back_to_gem_spec_homepage_if_unsupported_git_repo
+      Gem::Specification
+        .expects(:find_by_name)
+        .with("some_private_gem")
+        .returns(Gem::Specification.new("some_private_gem") { |spec| spec.homepage = "https://example/" })
+
+      outdated_gem = build(
+        :outdated_gem,
+        rubygems_source: false,
+        name: "some_private_gem",
+        git_source_uri: "git@private.example.com/repo.git",
+        current_git_version: "bedf6a5",
+        updated_git_version: "9c80944"
+      )
+
+      assert_equal "https://example/", outdated_gem.changelog_uri
     end
   end
 end


### PR DESCRIPTION
If the `Gemfile` sources a gem from a `gitlab.com` repo, we now show a diff URL for the changelog, like this:

https://gitlab.com/os85/httpx/-/compare/e250ea5...7278647

Previously this feature only worked with GitHub repos.