### PR TITLE
Remove internal constants from global scope

### DIFF
--- a/lib/bundle_update_interactive/changelog_locator.rb
+++ b/lib/bundle_update_interactive/changelog_locator.rb
@@ -3,13 +3,13 @@
 require "faraday"
 require "json"
 
-GITHUB_PATTERN = %r{^(?:https?://)?github\.com/([^/]+/[^/]+)(?:\.git)?/?}.freeze
-URI_KEYS = %w[source_code_uri homepage_uri bug_tracker_uri wiki_uri].freeze
-FILE_PATTERN = /changelog|changes|history|news|release/i.freeze
-EXT_PATTERN = /md|txt|rdoc/i.freeze
-
 module BundleUpdateInteractive
   class ChangelogLocator
+    GITHUB_PATTERN = %r{^(?:https?://)?github\.com/([^/]+/[^/]+)(?:\.git)?/?}.freeze
+    URI_KEYS = %w[source_code_uri homepage_uri bug_tracker_uri wiki_uri].freeze
+    FILE_PATTERN = /changelog|changes|history|news|release/i.freeze
+    EXT_PATTERN = /md|txt|rdoc/i.freeze
+
     class GitHubRepo
       def self.from_uris(*uris)
         uris.flatten.each do |uri|


### PR DESCRIPTION
Constants used by `ChangelogLocator` were inadvertently placed in global scope. This PR moves them inside the `ChangelogLocator` class where they belong.