### PR TITLE
Add `--minor` and `--patch` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ https://github.com/rails/rails/compare/5a8d894...77dfa65
 
 This feature currently works for GitHub, GitLab, and Bitbucket repos.
 
+### Limit updates by version type
+
+In order to reduce the risks of an update, `bundle update-interactive` can be limited to either patch or minor level updates with the `--patch` and `--minor` options.
+
+```sh
+# Limit updates to patch version changes (exclude minor and major updates)
+bundle update-interactive --patch
+
+# Limit updates to patch and minor version changes (exclude major updates)
+bundle update-interactive --minor
+```
+
+For example, consider a lock file that currently has rack 2.0.3. The latest version of rack is 3.1.7, but updating by a major version is risky. Instead, we'd like to update to the latest 2.0.x version first, which is 2.0.9. We can accomplish this with the `--patch` option.
+
+Once this update is successful, we might wish to update rack from 2.0.9 to the last 2.x version, 2.2.9, before going to version 3. We can accomplish this with the `--minor` option.
+
 ### Limit impact by Gemfile groups
 
 The effects of `bundle update-interactive` can be limited to one or more Gemfile groups using the `--exclusively` option:

--- a/lib/bundle_update_interactive/bundler_commands.rb
+++ b/lib/bundle_update_interactive/bundler_commands.rb
@@ -6,13 +6,19 @@ require "shellwords"
 module BundleUpdateInteractive
   module BundlerCommands
     class << self
-      def update_gems_conservatively(*gems)
-        system "#{bundle_bin.shellescape} update --conservative #{gems.flatten.map(&:shellescape).join(' ')}"
+      def update_gems_conservatively(*gems, level: nil)
+        command = ["#{bundle_bin.shellescape} update"]
+        command << "--minor" if level == :minor
+        command << "--patch" if level == :patch
+        command.push("--conservative #{gems.flatten.map(&:shellescape).join(' ')}")
+        system command.join(" ")
       end
 
-      def read_updated_lockfile(*gems)
+      def read_updated_lockfile(*gems, level: nil)
         command = ["#{bundle_bin.shellescape} lock --print"]
         command << "--conservative" if gems.any?
+        command << "--minor" if level == :minor
+        command << "--patch" if level == :patch
         command << "--update"
         command.push(*gems.flatten.map(&:shellescape))
 

--- a/lib/bundle_update_interactive/cli.rb
+++ b/lib/bundle_update_interactive/cli.rb
@@ -46,7 +46,7 @@ module BundleUpdateInteractive
 
     def generate_report(options)
       whisper "Resolving latest gem versions..."
-      report = Report.generate(groups: options.exclusively)
+      report = Report.generate(groups: options.exclusively, level: options.level)
       updateable_gems = report.updateable_gems
       return report if updateable_gems.empty?
 

--- a/lib/bundle_update_interactive/cli/options.rb
+++ b/lib/bundle_update_interactive/cli/options.rb
@@ -58,7 +58,7 @@ module BundleUpdateInteractive
       end
 
       def build_parser(options) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-        OptionParser.new do |parser|
+        OptionParser.new do |parser| # rubocop:disable Metrics/BlockLength
           parser.summary_indent = "  "
           parser.summary_width = 24
           parser.on(
@@ -69,6 +69,16 @@ module BundleUpdateInteractive
           end
           parser.on("-D", "Shorthand for --exclusively=development,test") do
             options.exclusively = %i[development test]
+          end
+          parser.on("-m", "--minor", "Only update to the latest minor version") do
+            raise Error, "Please specify EITHER --patch or --minor option, not both" unless options.level.nil?
+
+            options.level = :minor
+          end
+          parser.on("-p", "--patch", "Only update to the latest patch version") do
+            raise Error, "Please specify EITHER --patch or --minor option, not both" unless options.level.nil?
+
+            options.level = :patch
           end
           parser.on("-v", "--version", "Display version") do
             require "bundler"
@@ -83,7 +93,7 @@ module BundleUpdateInteractive
       end
     end
 
-    attr_accessor :exclusively
+    attr_accessor :exclusively, :level
 
     def initialize
       @exclusively = []

--- a/test/bundle_update_interactive/bundler_commands_test.rb
+++ b/test/bundle_update_interactive/bundler_commands_test.rb
@@ -33,6 +33,20 @@ module BundleUpdateInteractive
       assert_match(/bundle lock command failed/i, error.message)
     end
 
+    def test_read_updated_lockfile_runs_bundle_lock_with_patch_option
+      expect_backticks("/exe/bundle lock --print --patch --update", captures: "bundler output")
+      result = BundlerCommands.read_updated_lockfile(level: :patch)
+
+      assert_equal "bundler output", result
+    end
+
+    def test_read_updated_lockfile_runs_bundle_lock_with_minor_option
+      expect_backticks("/exe/bundle lock --print --minor --update", captures: "bundler output")
+      result = BundlerCommands.read_updated_lockfile(level: :minor)
+
+      assert_equal "bundler output", result
+    end
+
     private
 
     def expect_backticks(command, captures: "", success: true)

--- a/test/bundle_update_interactive/cli/options_test.rb
+++ b/test/bundle_update_interactive/cli/options_test.rb
@@ -40,6 +40,24 @@ module BundleUpdateInteractive
       assert_equal(0, status)
     end
 
+    def test_allows_patch_option_to_be_specified
+      options = CLI::Options.parse(%w[--patch])
+      assert_equal :patch, options.level
+    end
+
+    def test_allows_minor_option_to_be_specified
+      options = CLI::Options.parse(%w[--patch])
+      assert_equal :patch, options.level
+    end
+
+    def test_raises_if_both_minor_and_patch_options_are_specified
+      error = assert_raises(BundleUpdateInteractive::Error) do
+        CLI::Options.parse(%w[--patch --minor])
+      end
+
+      assert_match(/specify EITHER --patch or --minor option/i, error.message)
+    end
+
     def test_exclusively_is_empty_array_by_default
       options = CLI::Options.parse([])
       assert_empty options.exclusively

--- a/test/bundle_update_interactive/cli_test.rb
+++ b/test/bundle_update_interactive/cli_test.rb
@@ -44,7 +44,7 @@ module BundleUpdateInteractive
         VCR.use_cassette("changelog_requests") do
           updated_lockfile = File.read("Gemfile.lock.updated")
           BundlerCommands.expects(:read_updated_lockfile).returns(updated_lockfile)
-          BundlerCommands.expects(:update_gems_conservatively).with("addressable", "bigdecimal", "builder")
+          BundlerCommands.expects(:update_gems_conservatively).with("addressable", "bigdecimal", "builder", level: nil)
           mock_vulnerable_gems([])
 
           stdin_data = " j j \n" # SPACE,DOWN,SPACE,DOWN,SPACE,ENTER selects first three gems to update

--- a/test/bundle_update_interactive/report_test.rb
+++ b/test/bundle_update_interactive/report_test.rb
@@ -11,7 +11,7 @@ module BundleUpdateInteractive
       VCR.use_cassette("changelog_requests") do
         Dir.chdir(File.expand_path("../fixtures", __dir__)) do
           updated_lockfile = File.read("Gemfile.lock.updated")
-          BundlerCommands.expects(:read_updated_lockfile).with.returns(updated_lockfile)
+          BundlerCommands.expects(:read_updated_lockfile).with(level: nil).returns(updated_lockfile)
           mock_vulnerable_gems("actionpack", "rexml", "devise")
 
           report = Report.generate
@@ -24,7 +24,7 @@ module BundleUpdateInteractive
     end
 
     def test_generate_creates_a_report_of_updatable_gems_for_development_and_test_groups
-      VCR.use_cassette("changelog_requests") do
+      VCR.use_cassette("changelog_requests") do # rubocop:disable Metrics/BlockLength
         Dir.chdir(File.expand_path("../fixtures", __dir__)) do
           updated_lockfile = File.read("Gemfile.lock.development-test-updated")
           BundlerCommands.expects(:read_updated_lockfile).with(
@@ -42,7 +42,8 @@ module BundleUpdateInteractive
               web-console
               websocket
               xpath
-            ]
+            ],
+            level: nil
           ).returns(updated_lockfile)
           mock_vulnerable_gems("actionpack", "rexml", "devise")
 


### PR DESCRIPTION
# Motivation

As discussed in #20, we would like a way to limit the risk of batch updates. The options `--minor` and `--patch` could be used to limit gem updates to the highest patch or minor level, which should mean no breaking changes.

# Solution

Add the minor and patch options

# Todo

- [ ] 🐞 Debug: this doesn't seem to be working when I run it locally
- [ ] 🧪 Figure out a way to test calls to `system` in `bundler_commands_test.rb` like the `expect_backticks` helper. Add tests for `BundlerCommands.update_gems_conservatively`.
- [ ] 🧪 Add a fixture + integration test to clearly test the patch/minor options (`test/bundle_update_interactive_test.rb`)
- [ ] 🧹 Review bundler docs and adjust our documentation to communicate that minor/patch level updates will be prioritized (but not guaranteed, I think because of sub-dependencies)
- [ ] 🧹 Tidy the passing around of `level` in `report.rb`, is there a better way?
- [ ] 🧹 Tidy to remove rubocop disabling  in `cli/options.rb`

 