### PR TITLE
Fix crash when displaying prerelease → final version change

### DIFF
--- a/lib/bundle_update_interactive/semver_change.rb
+++ b/lib/bundle_update_interactive/semver_change.rb
@@ -10,10 +10,12 @@ module BundleUpdateInteractive
 
       @same_segments = new_segments.take_while.with_index { |seg, i| seg == old_segments[i] }
       @diff_segments = new_segments[same_segments.length..]
+
+      @changed = diff_segments.any? || old_segments.length != new_segments.length
     end
 
     def severity
-      return nil if diff_segments.empty?
+      return nil unless @changed
 
       SEVERITIES[same_segments.length] || :patch
     end

--- a/test/bundle_update_interactive/semver_change_test.rb
+++ b/test/bundle_update_interactive/semver_change_test.rb
@@ -3,9 +3,19 @@
 require "test_helper"
 
 module BundleUpdateInteractive
-  class SemverTest < Minitest::Test
+  class SemverChangeTest < Minitest::Test
     def test_prerelease_is_considered_patch
       change = SemverChange.new("7.2.0.beta2", "7.2.0.beta3")
+
+      assert_equal :patch, change.severity
+      assert_predicate change, :patch?
+
+      refute_predicate change, :minor?
+      refute_predicate change, :major?
+    end
+
+    def test_prerelease_to_final_is_considered_patch
+      change = SemverChange.new("7.2.0.rc1", "7.2.0")
 
       assert_equal :patch, change.severity
       assert_predicate change, :patch?
@@ -61,6 +71,12 @@ module BundleUpdateInteractive
       assert_equal "2.<1.6>", SemverChange.new("2.0.9", "2.1.6").format(&formatter)
       assert_equal "2.1.<6>", SemverChange.new("2.1.5", "2.1.6").format(&formatter)
       assert_equal "2.1.6.<1>", SemverChange.new("2.1.6", "2.1.6.1").format(&formatter)
+    end
+
+    def test_format_doesnt_apply_to_final_release
+      formatter = ->(str) { "<#{str}>" }
+
+      assert_equal "7.2.0", SemverChange.new("7.2.0.rc1", "7.2.0").format(&formatter)
     end
 
     def test_none_is_true_when_versions_are_identical


### PR DESCRIPTION
When `update-interactive` tried to format a prerelease → final version number change like this:

> 7.2.0.rc1 → 7.2.0

It would crash with a `KeyError` exception:

```
bundle_update_interactive/cli/row.rb:54:in 'Hash#fetch': key not found: nil (KeyError)
  from bundle_update_interactive/cli/row.rb:54:in 'BundleUpdateInteractive::CLI::Row#apply_semver_highlight'
```

This PR fixes the underlying bug and adds tests for this scenario.