### PR TITLE
Pin activesupport version used for testing to fix factory_bot issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 gemspec
 
+gem "activesupport", "~> 7.1.3" # Needed for factory_bot 6.3
 gem "factory_bot", "~> 6.3.0"
 gem "minitest", "~> 5.11"
 gem "minitest-snapshots", "~> 1.1"


### PR DESCRIPTION
We use an old version of `factory_bot` for testing against Ruby 2.7. That old version is incompatible with the just-released `activesupport` 7.2.0, so we need to pin activesupport for CI to pass.

These dependencies are used for development and testing only, so the change here does not have any runtime impact.