### PR TITLE
Don't use GitHub Releases as changelog URL if it is empty

### DIFF
--- a/lib/bundle_update_interactive/changelog_locator.rb
+++ b/lib/bundle_update_interactive/changelog_locator.rb
@@ -31,7 +31,8 @@ module BundleUpdateInteractive
         return "https://github.com/#{changelog_path}" if changelog_path
 
         releases_url = "https://github.com/#{path}/releases"
-        releases_url if HTTP.head("#{releases_url}/tag/v#{version}").success?
+        response = HTTP.get(releases_url)
+        releases_url if response.success? && response.body.include?("v#{version}")
       end
 
       private

--- a/lib/bundle_update_interactive/outdated_gem.rb
+++ b/lib/bundle_update_interactive/outdated_gem.rb
@@ -38,8 +38,8 @@ module BundleUpdateInteractive
       @changelog_uri =
         if (diff_url = build_git_diff_url)
           diff_url
-        elsif rubygems_source?
-          changelog_locator.find_changelog_uri(name: name, version: updated_version.to_s)
+        elsif (found_uri = rubygems_source? && locate_changelog_uri)
+          found_uri
         else
           begin
             Gem::Specification.find_by_name(name)&.homepage
@@ -56,6 +56,10 @@ module BundleUpdateInteractive
     private
 
     attr_reader :changelog_locator
+
+    def locate_changelog_uri
+      changelog_locator.find_changelog_uri(name: name, version: updated_version.to_s)
+    end
 
     def build_git_diff_url
       return nil unless git_version_changed?

--- a/test/bundle_update_interactive/changelog_locator_test.rb
+++ b/test/bundle_update_interactive/changelog_locator_test.rb
@@ -60,5 +60,16 @@ module BundleUpdateInteractive
         assert_nil uri
       end
     end
+
+    def test_returns_nil_when_project_is_on_github_but_is_not_using_releases
+      VCR.use_cassette("changelog_requests") do
+        # This gem doesn't publish changelog_uri metadata, it *is* on GitHub, but there is no
+        # CHANGELOG, etc. file, and the GitHub Releases page doesn't seem to have any data,
+        # so we don't have a way to discover its changelog.
+        uri = ChangelogLocator.new.find_changelog_uri(name: "parallel", version: "1.26.3")
+
+        assert_nil uri
+      end
+    end
   end
 end


### PR DESCRIPTION
Some gems, like [parallel](https://rubygems.org/gems/parallel), have no changelog at all. They are hosted on GitHub but don't make use of GitHub Releases, either.

Before, `update-interactive` would show GitHub Releases as the changelog URL in this scenario, even though the page doesn't contain any useful information. This is a bug.

```
parallel  1.25.1  →  1.26.3  https://github.com/grosser/parallel/releases
```

This PR fixes the bug by doing a better job at testing that the GitHub Releases page contains actual releases. If no useful changelog URL can be found, `update-interactive` now falls back to showing the gem's home page instead.

```
parallel  1.25.1  →  1.26.3  https://github.com/grosser/parallel
```