### PR TITLE
Create a git commit for each selected gem update when `--commit` is specified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           bundler: latest
+      - run: git config --global user.name 'github-actions[bot]'
+      - run: git config --global user.email 'github-actions[bot]@users.noreply.github.com'
       - run: bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ bundle ui
 
 ## Options
 
+- `--commit` [applies each gem update in a discrete git commit](#git-commits)
 - `--latest` [modifies the Gemfile if necessary to allow the latest gem versions](#allow-latest-versions)
 - `-D` / `--exclusively=GROUP` [limits updatable gems by Gemfile groups](#limit-impact-by-gemfile-groups)
 
@@ -68,6 +69,27 @@ Gems sourced from Git repositories are highlighted in cyan, regardless of the se
 Some gems, notably `rails`, are composed of smaller gems like `actionpack`, `activesupport`, `railties`, etc. Because of how these component gem versions are constrained, you cannot update just one of them; they all must be updated together.
 
 Therefore, if any Rails component has a security vulnerability, `bundle update-interactive` will automatically roll up that information into a single `rails` line item, so you can select it and upgrade all of its components in one shot.
+
+### Git commits
+
+Sometimes, updating gems can lead to bugs or regressions. To facilitate troubleshooting, `update-interactive` offers the ability to commit each selected gem update in its own git commit, complete with a descriptive commit message. You can then make use of tools like `git bisect` to more easily find the update that introduced the problem.
+
+To enable this behavior, pass the `--commit` option:
+
+```
+bundle update-interactive --commit
+```
+
+The gems you select to be updated will be applied in separate commits, like this:
+
+```
+* c9801382 Update activeadmin 3.2.2 → 3.2.3
+* 9957254b Update rexml 3.3.5 → 3.3.6
+* 4a4f2072 Update sass 1.77.6 → 1.77.8
+```
+
+> [!NOTE]
+> In rare cases, Bundler may not be able to update a gem separately, due to interdependencies between gem versions. If this happens, you will see a message like "attempted to update [GEM] but its version stayed the same."
 
 ### Held back gems
 

--- a/lib/bundle_update_interactive/cli.rb
+++ b/lib/bundle_update_interactive/cli.rb
@@ -17,7 +17,13 @@ module BundleUpdateInteractive
       puts "Updating the following gems."
       puts Table.updatable(selected_gems).render
       puts
-      updater.apply_updates(*selected_gems.keys)
+
+      if options.commit?
+        GitCommitter.new(updater).apply_updates_as_individual_commits(*selected_gems.keys)
+      else
+        updater.apply_updates(*selected_gems.keys)
+      end
+
       puts_gemfile_modified_notice if updater.modified_gemfile?
     rescue Exception => e # rubocop:disable Lint/RescueException
       handle_exception(e)

--- a/lib/bundle_update_interactive/cli/options.rb
+++ b/lib/bundle_update_interactive/cli/options.rb
@@ -61,9 +61,12 @@ module BundleUpdateInteractive
       end
 
       def build_parser(options) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-        OptionParser.new do |parser|
+        OptionParser.new do |parser| # rubocop:disable Metrics/BlockLength
           parser.summary_indent = "  "
           parser.summary_width = 24
+          parser.on("--commit", "Create a git commit for each selected gem update") do
+            options.commit = true
+          end
           parser.on("--latest", "Modify the Gemfile to allow the latest gem versions") do
             options.latest = true
           end
@@ -90,11 +93,16 @@ module BundleUpdateInteractive
     end
 
     attr_accessor :exclusively
-    attr_writer :latest
+    attr_writer :commit, :latest
 
     def initialize
       @exclusively = []
+      @commit = false
       @latest = false
+    end
+
+    def commit?
+      @commit
     end
 
     def latest?

--- a/lib/bundle_update_interactive/git_committer.rb
+++ b/lib/bundle_update_interactive/git_committer.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "shellwords"
+
+module BundleUpdateInteractive
+  class GitCommitter
+    def initialize(updater)
+      @updater = updater
+    end
+
+    def apply_updates_as_individual_commits(*gem_names)
+      assert_git_executable!
+      assert_working_directory_clean!
+
+      gem_names.flatten.each do |name|
+        updates = updater.apply_updates(name)
+        updated_gem = updates[name] || updates.values.first
+        next if updated_gem.nil?
+
+        commit_message = format_commit_message(updated_gem)
+        system "git add Gemfile Gemfile.lock", exception: true
+        system "git commit -m #{commit_message.shellescape}", exception: true
+      end
+    end
+
+    def format_commit_message(outdated_gem)
+      [
+        "Update",
+        outdated_gem.name,
+        outdated_gem.current_version.to_s,
+        outdated_gem.current_git_version,
+        "→",
+        outdated_gem.updated_version.to_s,
+        outdated_gem.updated_git_version
+      ].compact.join(" ")
+    end
+
+    private
+
+    attr_reader :updater
+
+    def assert_git_executable!
+      success = begin
+        `git --version`
+        Process.last_status.success?
+      rescue SystemCallError
+        false
+      end
+      raise Error, "git could not be executed" unless success
+    end
+
+    def assert_working_directory_clean!
+      status = `git status --untracked-files=no --porcelain`.strip
+      return if status.empty?
+
+      raise Error, "`git status` reports uncommitted changes; please commit or stash them them first!\n#{status}"
+    end
+  end
+end

--- a/test/bundle_update_interactive/cli/options_test.rb
+++ b/test/bundle_update_interactive/cli/options_test.rb
@@ -45,6 +45,7 @@ module BundleUpdateInteractive
 
       assert_empty options.exclusively
       refute_predicate options, :latest?
+      refute_predicate options, :commit?
     end
 
     def test_allows_exclusive_groups_to_be_specified_as_comma_separated
@@ -55,6 +56,12 @@ module BundleUpdateInteractive
     def test_dash_capital_d_is_a_shortcut_for_exclusively_development_test
       options = CLI::Options.parse(%w[-D])
       assert_equal %i[development test], options.exclusively
+    end
+
+    def test_commit_can_be_enabled
+      options = CLI::Options.parse(["--commit"])
+
+      assert_predicate options, :commit?
     end
 
     def test_latest_can_be_enabled

--- a/test/bundle_update_interactive/git_committer_test.rb
+++ b/test/bundle_update_interactive/git_committer_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module BundleUpdateInteractive
+  class GitCommitterTest < Minitest::Test
+    def setup
+      @git_committer = GitCommitter.new(nil)
+    end
+
+    def test_format_commit_message
+      gem = build(:outdated_gem, name: "activeadmin", current_version: "3.2.2", updated_version: "3.2.3")
+
+      assert_equal "Update activeadmin 3.2.2 → 3.2.3", @git_committer.format_commit_message(gem)
+    end
+
+    def test_format_commit_message_with_git_version
+      gem = build(
+        :outdated_gem,
+        name: "rails",
+        current_version: "7.2.1",
+        current_git_version: "5a8d894",
+        updated_version: "7.2.1",
+        updated_git_version: "77dfa65"
+      )
+
+      assert_equal "Update rails 7.2.1 5a8d894 → 7.2.1 77dfa65", @git_committer.format_commit_message(gem)
+    end
+
+    def test_apply_updates_as_individual_commits_raises_if_git_raises
+      @git_committer.stubs(:`).with("git --version").raises(Errno::ENOENT)
+
+      error = assert_raises(Error) { @git_committer.apply_updates_as_individual_commits }
+      assert_equal "git could not be executed", error.message
+    end
+
+    def test_apply_updates_as_individual_commits_raises_if_git_does_not_succeed
+      @git_committer.stubs(:`).with("git --version").returns("")
+      Process.stubs(:last_status).returns(stub(success?: false))
+
+      error = assert_raises(Error) { @git_committer.apply_updates_as_individual_commits }
+      assert_equal "git could not be executed", error.message
+    end
+
+    def test_apply_updates_as_individual_commits_raises_if_there_are_uncommitted_files
+      @git_committer.stubs(:`).with("git --version").returns("")
+      @git_committer.stubs(:`).with("git status --untracked-files=no --porcelain").returns("M  Gemfile.lock")
+      Process.stubs(:last_status).returns(stub(success?: true))
+
+      error = assert_raises(Error) { @git_committer.apply_updates_as_individual_commits }
+      assert_equal <<~MESSAGE.strip, error.message
+        `git status` reports uncommitted changes; please commit or stash them them first!
+        M  Gemfile.lock
+      MESSAGE
+    end
+  end
+end


### PR DESCRIPTION
Sometimes, updating gems can lead to bugs or regressions. To facilitate troubleshooting, this PR introduces the ability to commit each selected gem update in its own git commit, complete with a descriptive commit message. You can then make use of tools like `git bisect` to more easily find the update that introduced the problem.

To enable this behavior, pass the `--commit` option:

```
bundle update-interactive --commit
```

The gems you select to be updated will be applied in separate commits, like this:

```
* c9801382 Update activeadmin 3.2.2 → 3.2.3
* 9957254b Update rexml 3.3.5 → 3.3.6
* 4a4f2072 Update sass 1.77.6 → 1.77.8
```

Supersedes #50 and #51. Closes #49.