### PR TITLE
Ensure gem list is sorted, regardless of Bundler output

### DIFF
--- a/lib/bundle_update_interactive/cli/table.rb
+++ b/lib/bundle_update_interactive/cli/table.rb
@@ -47,7 +47,7 @@ module BundleUpdateInteractive
       end
 
       def gem_names
-        rows.keys
+        rows.keys.sort
       end
 
       def render_header
@@ -61,7 +61,7 @@ module BundleUpdateInteractive
 
       def render
         lines = [render_header]
-        rows.keys.sort.each { |name| lines << render_gem(name) }
+        gem_names.each { |name| lines << render_gem(name) }
         lines.join("\n")
       end
 

--- a/test/bundle_update_interactive/cli/multi_select_test.rb
+++ b/test/bundle_update_interactive/cli/multi_select_test.rb
@@ -20,6 +20,17 @@ module BundleUpdateInteractive
         }
       end
 
+      def test_renders_choices_in_alphabetical_order
+        @outdated_gems = @outdated_gems.to_a.reverse.to_h
+
+        stdout, _stderr, _status = capture_io_and_exit_status(stdin_data: "\n") do
+          MultiSelect.prompt_for_gems_to_update(@outdated_gems)
+        end
+        stdout = BundleUpdateInteractive.pastel.strip(stdout)
+
+        assert_equal ["⬡ a", "⬡ b", "⬡ c"], stdout.scan(/⬡ [a-z]/)
+      end
+
       def test_pressing_a_selects_all_rows
         selected = use_menu_with_keypress "a"
 


### PR DESCRIPTION
Until now `update-interactive` has been displaying gems exactly as they are emitted by Bundler, without any explicit sorting. Since Bundler's output and lock file are generally sorted alphabetically, this works out fine. However, this is more of a coincidence than a guarantee.

This PR makes the desired behavior explicit by sorting the names of gems when rendering the multi-select menu, with a corresponding unit test.