### PR TITLE
Add `--only-explicit` option to exclude indirect dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ bundle ui
 
 - `--commit` [applies each gem update in a discrete git commit](#git-commits)
 - `--latest` [modifies the Gemfile if necessary to allow the latest gem versions](#allow-latest-versions)
+- `--only-explicit` [updates Gemfile gems only (excluding indirect dependencies)](#exclude-indirect-dependencies)
 - `-D` / `--exclusively=GROUP` [limits updatable gems by Gemfile groups](#limit-impact-by-gemfile-groups)
 
 ## Features
@@ -144,6 +145,16 @@ Then `bundle update-interactive` will show a diff link instead of a changelog, s
 https://github.com/rails/rails/compare/5a8d894...77dfa65
 
 This feature currently works for GitHub, GitLab, and Bitbucket repos.
+
+### Exclude indirect dependencies
+
+Just like with `bundle outdated`, you can pass `--only-explicit` to limit updates to only gems that are explicitly listed in the Gemfile.
+
+```sh
+bundle update-interactive --only-explicit
+```
+
+This will omit indirect dependencies from the list of gems that can be updated.
 
 ### Limit impact by Gemfile groups
 

--- a/lib/bundle_update_interactive/cli.rb
+++ b/lib/bundle_update_interactive/cli.rb
@@ -61,7 +61,7 @@ module BundleUpdateInteractive
     def generate_report(options)
       whisper "Resolving latest gem versions..."
       updater_class = options.latest? ? Latest::Updater : Updater
-      updater = updater_class.new(groups: options.exclusively)
+      updater = updater_class.new(groups: options.exclusively, only_explicit: options.only_explicit?)
 
       report = updater.generate_report
       unless report.empty?

--- a/lib/bundle_update_interactive/cli/options.rb
+++ b/lib/bundle_update_interactive/cli/options.rb
@@ -71,6 +71,9 @@ module BundleUpdateInteractive
             parser.on("--latest", "Modify the Gemfile to allow the latest gem versions") do
               options.latest = true
             end
+            parser.on("--only-explicit", "Update Gemfile gems only (no indirect dependencies)") do
+              options.only_explicit = true
+            end
             parser.on(
               "--exclusively=GROUP",
               "Update gems exclusively belonging to the specified Gemfile GROUP(s)"
@@ -94,12 +97,13 @@ module BundleUpdateInteractive
       end
 
       attr_accessor :exclusively
-      attr_writer :commit, :latest
+      attr_writer :commit, :latest, :only_explicit
 
       def initialize
         @exclusively = []
         @commit = false
         @latest = false
+        @only_explicit = false
       end
 
       def commit?
@@ -108,6 +112,10 @@ module BundleUpdateInteractive
 
       def latest?
         @latest
+      end
+
+      def only_explicit?
+        @only_explicit
       end
     end
   end

--- a/lib/bundle_update_interactive/gemfile.rb
+++ b/lib/bundle_update_interactive/gemfile.rb
@@ -22,5 +22,9 @@ module BundleUpdateInteractive
     def dependencies
       @dependencies.values
     end
+
+    def gem_names
+      dependencies.map(&:name)
+    end
   end
 end

--- a/test/bundle_update_interactive/cli/options_test.rb
+++ b/test/bundle_update_interactive/cli/options_test.rb
@@ -47,6 +47,7 @@ module BundleUpdateInteractive
         assert_empty options.exclusively
         refute_predicate options, :latest?
         refute_predicate options, :commit?
+        refute_predicate options, :only_explicit?
       end
 
       def test_allows_exclusive_groups_to_be_specified_as_comma_separated
@@ -69,6 +70,12 @@ module BundleUpdateInteractive
         options = Options.parse(["--latest"])
 
         assert_predicate options, :latest?
+      end
+
+      def test_only_explicit_can_be_enabled
+        options = Options.parse(["--only_explicit"])
+
+        assert_predicate options, :only_explicit?
       end
 
       def test_raises_exception_when_given_a_positional_argment

--- a/test/fixtures/integration/with_indirect/Gemfile
+++ b/test/fixtures/integration/with_indirect/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gem "mail"

--- a/test/fixtures/integration/with_indirect/Gemfile.lock
+++ b/test/fixtures/integration/with_indirect/Gemfile.lock
@@ -1,0 +1,30 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    date (3.4.0)
+    mail (2.8.0)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    mini_mime (1.1.4)
+    net-imap (0.5.1)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.0)
+      net-protocol
+    timeout (0.4.2)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  mail
+
+BUNDLED WITH
+   2.5.23

--- a/test/integration/cli_integration_test.rb
+++ b/test/integration/cli_integration_test.rb
@@ -40,6 +40,15 @@ module BundleUpdateInteractive
       LOCK
     end
 
+    def test_omits_indirect_gems_when_only_explicit_option_is_passed
+      out, _gemfile, _lockfile = within_fixture_copy("integration/with_indirect") do
+        run_bundle_update_interactive(argv: ["--only-explicit"], key_presses: "\n")
+      end
+
+      assert_includes out, "1 gem can be updated."
+      assert_includes out, "‣ ⬡ mail"
+    end
+
     def test_updates_lock_file_and_gemfile_to_accommodate_latest_version_when_latest_option_is_specified
       latest_minitest_version = fetch_latest_gem_version_from_rubygems_api("minitest")
 


### PR DESCRIPTION
You can now pass `--only-explicit`, which limits updates to only those gems that are explicitly listed in the Gemfile. In other words, this option lets you ignore indirect dependencies.

Closes #55 