### PR TITLE
Fix mocha stubbing_method_on_nil deprecation warning

### DIFF
--- a/test/support/mocha.rb
+++ b/test/support/mocha.rb
@@ -3,6 +3,5 @@
 require "mocha/minitest"
 
 Mocha.configure do |config|
-  config.stubbing_method_on_nil = :prevent
   config.stubbing_non_existent_method = :prevent
 end


### PR DESCRIPTION
Fixes the following warning:

> Mocha deprecation warning at test/support/mocha.rb:6:in 'block in <top (required)>': `Mocha::Configuration#stubbing_method_on_nil=` is deprecated and will be removed in a future release. `nil` is frozen in Ruby >= v2.2 and Mocha will be dropping support for Ruby v2.1. At that point it won't be possible to stub methods on `nil` any more.