### PR TITLE
Fetch changelogs concurrently for significant speed boost

### DIFF
--- a/bundle_update_interactive.gemspec
+++ b/bundle_update_interactive.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   # Runtime dependencies
   spec.add_dependency "bundler", "~> 2.0"
   spec.add_dependency "bundler-audit", ">= 0.9.1"
+  spec.add_dependency "concurrent-ruby", ">= 1.3.4"
   spec.add_dependency "launchy", ">= 2.5.0"
   spec.add_dependency "pastel", ">= 0.8.0"
   spec.add_dependency "tty-prompt", ">= 0.23.1"

--- a/lib/bundle_update_interactive/cli.rb
+++ b/lib/bundle_update_interactive/cli.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require "bundler"
+require "concurrent/promises"
 
 module BundleUpdateInteractive
   class CLI
+    include Concurrent::Promises::FactoryMethods
+
     def run(argv: ARGV) # rubocop:disable Metrics/AbcSize
       options = Options.parse(argv)
       report, updater = generate_report(options)
@@ -64,13 +67,19 @@ module BundleUpdateInteractive
       updater = updater_class.new(groups: options.exclusively, only_explicit: options.only_explicit?)
 
       report = updater.generate_report
-      unless report.empty?
-        whisper "Checking for security vulnerabilities..."
-        report.scan_for_vulnerabilities!
-        progress "Finding changelogs", report.all_gems.values, &:changelog_uri
-      end
+      populate_vulnerabilities_and_changelogs_concurrently(report) unless report.empty?
 
       [report, updater]
+    end
+
+    def populate_vulnerabilities_and_changelogs_concurrently(report)
+      whisper "Checking for security vulnerabilities..."
+      scan_promise = future(report, &:scan_for_vulnerabilities!)
+      changelog_promises = report.all_gems.map do |_, outdated_gem|
+        future(outdated_gem, &:changelog_uri)
+      end
+      progress "Finding changelogs", changelog_promises, &:value!
+      scan_promise.value!
     end
 
     def whisper(message)

--- a/lib/bundle_update_interactive/thread_pool.rb
+++ b/lib/bundle_update_interactive/thread_pool.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+module BundleUpdateInteractive
+  class ThreadPool
+    include Concurrent::Promises::FactoryMethods
+
+    def initialize(max_threads:)
+      @executor = Concurrent::ThreadPoolExecutor.new(
+        min_threads: 0,
+        max_threads: max_threads,
+        max_queue: 0
+      )
+    end
+
+    def default_executor
+      @executor
+    end
+  end
+end


### PR DESCRIPTION
Inspired by the suggestions in #66, this PR incorporates the `concurrent-ruby` gem to fetch changelogs concurrently. Doing so can yield a significant speed boost.

For example, for a project with 80 outdated gems, `bundle ui` in this PR now takes just 7 seconds to run from startup to rendering the complete list of changelogs:

```
real	0m7.025s
user	0m2.131s
sys	0m0.521s
```

Whereas `bundle ui` on the main branch in the same scenario takes 36 seconds:

```
real	0m36.357s
user	0m2.531s
sys	0m0.684s
```

~For now I'm considering this a proof-of-concept. It may need testing and more error handling (e.g. to deal with HTTP 429 errors) prior to merging.~

Edit: To prevent overloading github.com and rubygems.org when fetching changelogs, I limited the concurrency to 25 threads. I tested with a project with over 100 outdated gems and did not encounter any 429 errors. Increasing the limit beyond 25 threads did not seem to yield any additional speed improvement.