### PR TITLE
Add cgi development dependency to fix vcr on Ruby 3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "activesupport", "~> 7.1.3" # Needed for factory_bot 6.3
+gem "cgi" # Needed for vcr on Ruby 3.5+
 gem "factory_bot", "~> 6.3.0"
 gem "minitest", "~> 5.11"
 gem "minitest-snapshots", "~> 1.1"


### PR DESCRIPTION
This fixes the following error:

```
/home/runner/work/bundle_update_interactive/bundle_update_interactive/vendor/bundle/ruby/3.5.0+1/gems/i18n-1.14.7/lib/i18n/exceptions.rb:3: warning: CGI library is removed from Ruby 3.5. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
/home/runner/work/bundle_update_interactive/bundle_update_interactive/vendor/bundle/ruby/3.5.0+1/gems/vcr-6.3.1/lib/vcr/configuration.rb:505:in 'Kernel#method': undefined method 'parse' for class '#<Class:CGI>' (NameError)

      self.query_parser = CGI.method(:parse)
                             ^^^^^^^
```