### PR TITLE
Fix mingw/mswin deprecation warnings when running tests

### DIFF
--- a/test/fixtures/Gemfile
+++ b/test/fixtures/Gemfile
@@ -35,7 +35,7 @@ gem "redis", "~> 5.0"
 # gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
+gem "tzinfo-data", platforms: %i[ jruby windows ]
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
@@ -48,7 +48,7 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem "debug", platforms: %i[ mri windows ]
 end
 
 group :development do


### PR DESCRIPTION
Fixes the following test warnings:

```
[DEPRECATED] Platform :mingw, :mswin, :x64_mingw is deprecated. Please use platform :windows instead.
[DEPRECATED] Platform :mingw, :x64_mingw is deprecated. Please use platform :windows instead.
```